### PR TITLE
cards can be dragged into the desired order

### DIFF
--- a/balatro-demo.p8
+++ b/balatro-demo.p8
@@ -455,13 +455,23 @@ special_cards = {
 			description = "Multiplies your mult by 1.5",
 		}),
 		joker_obj:new({
-			name = "Times 2 Mult",
-			price = 7,
+			name = "photograph",
+			price = 5,
+			card_affected=nil,
+			card_effect=function(self,card)
+				if self.card_affected==nil and card:is_face() then
+					self.card_affected=card
+				end
+				if self.card_affected==card then
+					multiply_mult(2, card)
+					add_sparkle(34,self,9)
+				end
+			end,
 			effect = function(self)
-				multiply_mult(2, self)
+				self.card_affected=nil
 			end,
 			sprite_index = 133, 
-			description = "Multiplies your mult by 2",
+			description = "first played face card gives\nx2 mult when scored",
 		}),
 		joker_obj:new({
 			name = "Times 3 Mult",

--- a/balatro-demo.p8
+++ b/balatro-demo.p8
@@ -1193,6 +1193,8 @@ end
 -- yield commands can be used
 function score_hand()
 	pause(5) -- wait for sfx
+ -- card are processed left-to-right
+	sort_by_x(scored_cards)
 	-- Score cards 
 	for card in all(scored_cards) do
 		add_chips( card.chips + card.effect_chips, card )

--- a/balatro-demo.p8
+++ b/balatro-demo.p8
@@ -1777,17 +1777,15 @@ function hand_collision_down()
 	for card in all(hand) do
 		if card:moused() then
 				card:pickup()
+				card.drop_at=hand_collision_up
 				break
 		end
 	end
 end
 
---function hand_collision_up()
-function card_obj:drop_at(px,py)
-	-- todo: detect movement
+-- drop a dragged card or click
+function hand_collision_up(self,px,py)
 	if(self.picked_up.moved) then
-		-- todo: drop in hand and re-sort
-			error_message=tostr(py)
 		if py < 50 or my > 102 then
 			return
 		end
@@ -1795,7 +1793,7 @@ function card_obj:drop_at(px,py)
 		self.pos_y = py
 		sort_by_x(hand)
 		distribute_hand()
-	else
+	else -- click, not drop
 		sfx(sfx_card_select)
 		select_hand(self)
 		update_selected_cards()

--- a/balatro-demo.p8
+++ b/balatro-demo.p8
@@ -153,6 +153,7 @@ function item_obj:reset()
 	self.pos_y=deck_sprite_pos_y
 end
 function item_obj:draw()
+	if(picked_up_item==self)return
 	-- animation
 	if self.frames > 0 then
 		self.frames -= 1

--- a/balatro-demo.p8
+++ b/balatro-demo.p8
@@ -207,7 +207,7 @@ end
 -- more than 1 pixel between
 -- mouse_down and mouse_up
 function item_obj:detect_moved()
-	if(self.picked_up==nil) return
+	if(not self.picked_up) return
 	if(self.picked_up.moved) return
 	if abs(mx-self.picked_up.mx)>1
 		or abs(my-self.picked_up.my)>1
@@ -218,7 +218,7 @@ end
 
 function item_obj:drop()
 	if(picked_up_item!=self) return
-	if(self.picked_up==nil) return
+	if(not self.picked_up) return
 	self:drop_at(
 		mx-self.picked_up.offx,
 		my-self.picked_up.offy
@@ -270,7 +270,7 @@ function card_obj:draw_at(x,y)
 end
 
 function card_obj:draw_at_mouse()
-	if (self.picked_up == nil) return
+	if (not self.picked_up) return
 	self:draw_at(
 		mx-self.picked_up.offx,
 		my-self.picked_up.offy
@@ -1026,8 +1026,8 @@ end
 btn_frames=0
 
 function _update()
-    mx = stat(32)
-    my = stat(33)
+	mx = stat(32)
+	my = stat(33)
  -- check score_hand animation
 	if costatus(animation)!='dead' then
 		coresume(animation)
@@ -1049,7 +1049,7 @@ function _update()
 	if btn(5) then
 		if btn_frames==0 then 
 			mouse_down()
-		elseif picked_up_item != nil then
+		elseif picked_up_item then
 			-- detect drag action
 			picked_up_item:detect_moved()
 		end
@@ -1093,7 +1093,7 @@ end
 -- handle mouse-up event
 -- process clicks and drags
 function mouse_up()
-	if(picked_up_item == nil) return
+	if(not picked_up_item) return
 	picked_up_item:drop()
 	picked_up_item=nil
 end
@@ -1540,14 +1540,14 @@ end
 
 function draw_mouse(x, y)
 	palt(0x8000)
-	if picked_up_item != nil then
+	if picked_up_item then
 		picked_up_item:draw_at_mouse()
 	end
 	spr(192, x, y)
 end
 
 function draw_tooltips(x,y)
-	if picked_up_item != nil then
+	if picked_up_item  then
 		return -- none of these other
        		-- cards are targets.
 	end
@@ -2066,24 +2066,6 @@ function sort_by(property,cards)
 	end
 end
 
-function get_rank_add(rank,inc)
-	idx=find_rank_index(rank)
-	result=((idx+inc-1)%#ranks)+1
-	return result
-end
-
-function find_rank_index(rank)
-	if type(rank) == "string" then
-		for i,r in pairs(ranks) do
-			if(r.rank==rank) return i
-		end
-	else
-		for i,r in pairs(ranks) do
-			if(r==rank) return i
-		end
-	end
-end
-
 function get_special_card_by_name(name, type)
 	for special_card_type, v in pairs(special_cards) do		
 		if special_card_type == type then
@@ -2100,7 +2082,6 @@ end
 function change_to_suit(suit, tarot)
 	if #selected_cards <= 3 then
 		for card in all(selected_cards) do
-			card.sprite_index = card.rank.sprite_index
 			card.suit = suit 
 			card.selected = false
 			card.pos_y = card.pos_y + 10

--- a/balatro-demo.p8
+++ b/balatro-demo.p8
@@ -295,7 +295,7 @@ function card_obj:set_rank(r)
 end
 
 function card_obj:plus_order(d)
-	return ((self.order+d-1) % 13) + 1
+	return ((self.order-d-1) % 13) + 1
 end
 
 function card_obj:add_rank(d)


### PR DESCRIPTION
I added some mouse code to allow items to be dragged and dropped, in addition to being clicked.  now card selection happens on mouse_up instead of mouse_down.

The drop operation really only requires two things: sorting the hand by the new X-position, and then repositioning the cards so they're evenly-spaced again.  For the sort operation I was able to repurpose the existing insertion sort, by making it work on multiple object properties.  Since I needed to sort in the opposite order from rank, I had to reverse the `order` property, which required fixes to the Strength card.  For the hand positioning, the `place` method already supports animation so the cards glide around gracefully to their new spots.

I put most of the mouse code in `item_obj` so that it is inherited by `joker_obj`, so reordering jokers shouldn't require much more code.